### PR TITLE
Require Scan Visor to exit Elite Research through Ore Processing

### DIFF
--- a/src/electron/models/prime/regions/phazonMines.ts
+++ b/src/electron/models/prime/regions/phazonMines.ts
@@ -47,7 +47,7 @@ export function phazonMines(): RegionObject[] {
     {
       name: 'Mine Security Station',
       locations: {
-        [PrimeLocation.STORAGE_DEPOT_A]: (items: PrimeItemCollection) => items.canLayPowerBombs() && items.has(PrimeItem.PLASMA_BEAM)
+        [PrimeLocation.STORAGE_DEPOT_A]: (items: PrimeItemCollection) => items.canLayPowerBombs() && items.has(PrimeItem.PLASMA_BEAM) && items.has(PrimeItem.SCAN_VISOR)
       },
       exits: {
         'Security Access A': (items: PrimeItemCollection) => items.has(PrimeItem.ICE_BEAM),

--- a/src/electron/models/prime/regions/phazonMines.ts
+++ b/src/electron/models/prime/regions/phazonMines.ts
@@ -63,7 +63,7 @@ export function phazonMines(): RegionObject[] {
       exits: {
         'Ore Processing': (items: PrimeItemCollection, settings: PrimeRandomizerSettings) => {
           const baseReqs = items.canBoost() && items.canLayBombs() && items.has(PrimeItem.ICE_BEAM)
-            && items.has(PrimeItem.SPACE_JUMP_BOOTS);
+            && items.has(PrimeItem.SPACE_JUMP_BOOTS) && items.has(PrimeItem.SCAN_VISOR);
 
           if (settings.pointOfNoReturnItems === PointOfNoReturnItems.ALLOW_ALL) {
             return baseReqs;


### PR DESCRIPTION
Need scan visor to activate the platforms and the laser.