### PR TITLE
Boostless Elite Research to Ore Processing

### DIFF
--- a/src/common/data/settingsDetails.ts
+++ b/src/common/data/settingsDetails.ts
@@ -311,8 +311,8 @@ export const details: SettingsDetails = {
     description: `Elite Research can be entered from the Research Access door with an Infinite Boost clip.`,
     difficulty: Difficulty.NORMAL
   },
-  eliteResearchLaserItemWithoutBoost: {
-    name: 'Elite Research Laser Item without Boost Ball',
+  eliteResearchLaserWithoutBoost: {
+    name: 'Elite Research Laser without Boost Ball',
     description: `You can get the laser turret to spin by wedging the morph ball in the spinner, bombing out, and then spinning the morph ball while in the spinner before it locks you in.`,
     difficulty: Difficulty.EASY
   },

--- a/src/electron/models/prime/regions/phazonMines.ts
+++ b/src/electron/models/prime/regions/phazonMines.ts
@@ -61,20 +61,21 @@ export function phazonMines(): RegionObject[] {
       locations: {
         [PrimeLocation.ELITE_RESEARCH_PHAZON_ELITE]: (items: PrimeItemCollection) => items.canLayPowerBombs(),
         [PrimeLocation.ELITE_RESEARCH_LASER]: (items: PrimeItemCollection, settings: PrimeRandomizerSettings) => {
-          const boostReqs = settings.tricks.eliteResearchLaserItemWithoutBoost || items.canBoost();
+          const boostReqs = settings.tricks.eliteResearchLaserWithoutBoost || items.canBoost();
           return boostReqs && items.canLayBombs() && items.has(PrimeItem.SPACE_JUMP_BOOTS) && items.has(PrimeItem.SCAN_VISOR);
         }
       },
       exits: {
         'Ore Processing': (items: PrimeItemCollection, settings: PrimeRandomizerSettings) => {
-          const baseReqs = items.canBoost() && items.canLayBombs() && items.has(PrimeItem.ICE_BEAM)
+          const boostReqs = items.canBoost() || settings.tricks.eliteResearchLaserWithoutBoost;
+          const baseReqs = items.canLayBombs() && items.has(PrimeItem.ICE_BEAM)
             && items.has(PrimeItem.SPACE_JUMP_BOOTS) && items.has(PrimeItem.SCAN_VISOR);
 
           if (settings.pointOfNoReturnItems === PointOfNoReturnItems.ALLOW_ALL) {
-            return baseReqs;
+            return boostReqs && baseReqs;
           }
 
-          return items.canSpider() && baseReqs;
+          return items.canSpider() && boostReqs && baseReqs;
         },
         'Mine Security Station': (items: PrimeItemCollection) => items.has(PrimeItem.WAVE_BEAM) && items.has(PrimeItem.ICE_BEAM)
       }

--- a/src/electron/models/prime/tricks.ts
+++ b/src/electron/models/prime/tricks.ts
@@ -28,7 +28,7 @@ export class Tricks extends SettingsFlags {
   destroyBombCoversWithPowerBombs = false;
   earlyPhendranaBehindIceItemsWithIS = false;
   eliteResearchInfiniteBoostClip = false;
-  eliteResearchLaserItemWithoutBoost = false;
+  eliteResearchLaserWithoutBoost = false;
   exitPhendranaCanyonNoItems = false;
   exitQuarantineCaveRuinedCourtyardSlopeJump = false;
   fieryShoresAccessWithoutMorphGrapple = false;


### PR DESCRIPTION
Changes the Elite Research laser trick to also be used for getting to Ore Processing without boost. Adjusts the trick name accordingly.