### PR TITLE
Add GitHub action for publishing on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: Build
+
+on: push
+
+env:
+  CARGO_TERM_COLOR: always
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    
+    - name: Add Salt
+      run: sed -i "s/getNumericSeed()/getNumericSeed('${{ secrets.RELEASE_SALT }}')/" src/electron/models/prime/randomizer.ts
+    - name: Enable Nightly Rust Toolchain
+      run: rustup toolchain install nightly
+    - name: Add PowerPC toolchain
+      run: rustup target add --toolchain nightly powerpc-unknown-linux-gnu
+    - name: NPM Install
+      run: npm install
+    - name: Build Linux App
+      run: npm run electron:linux
+
+  macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    
+    - name: Add Salt
+      run: sed -i.bak "s/getNumericSeed()/getNumericSeed('${{ secrets.RELEASE_SALT }}')/" src/electron/models/prime/randomizer.ts
+    - name: Enable Nightly Rust Toolchain
+      run: rustup toolchain install nightly
+    - name: Add PowerPC toolchain
+      run: rustup target add --toolchain nightly powerpc-unknown-linux-gnu
+    - name: NPM Install
+      run: npm install
+    - name: Build macOS App
+      run: npm run electron:mac
+
+  windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    
+    - name: Add Salt
+      run: $x = get-content src/electron/models/prime/randomizer.ts | %{$_ -replace "getNumericSeed\(\)", "getNumericSeed('${{ secrets.RELEASE_SALT }}')" }; set-content src/electron/models/prime/randomizer.ts $x
+    - name: Enable nightly Rust Toolchain
+      run: rustup toolchain install nightly
+    - name: Add PowerPC toolchain
+      run: rustup target add --toolchain nightly powerpc-unknown-linux-gnu
+    - name: NPM Install
+      run: npm install
+    - name: Build Windows App
+      run: npm run electron:windows


### PR DESCRIPTION
With this workflow, all commits on this repository will trigger a job that runs `npm install` and `npm run electron:<PLATFORM>` on Linux, Windows and macOS.
This depends on a secret named RELEASE_SALT.

When running a `electron-builder build` commands during a GitHub action, if it's building a Git Tag that has a GitHub Release in draft mode the executables are attached to the release automatically:
![image](https://user-images.githubusercontent.com/884928/92642769-ff6ab200-f2e0-11ea-9065-5c68852494a0.png)

For more details, I suggest you look at electron-builder doc because this was actually a surprise for me.