### PR TITLE
Overgrown Cavern logic fixes

### DIFF
--- a/src/common/data/settingsDetails.ts
+++ b/src/common/data/settingsDetails.ts
@@ -595,6 +595,11 @@ export const details: SettingsDetails = {
     description: `You can skip the Grapple Beam by scan dashing to the Quarantine Monitor platform from the elevator platform.`,
     difficulty: Difficulty.NORMAL
   },
+  tallonTransportTunnelCMinimumReqs: {
+    name: 'Tallon Transport Tunnel C - Minimum Requirements',
+    description: `The roots near Overgrown Cavern can be rolled under with Morph Ball. The remaining roots can be climbed over without Space Jump.`,
+    difficulty: Difficulty.TRIVIAL
+  },
   towerChamberNoGravity: {
     name: 'Tower Chamber without Gravity Suit',
     description: `The ledge can be reached by underwater slope jumping to the door without the Gravity Suit equipped.`,

--- a/src/electron/models/prime/regions/tallonOverworld.ts
+++ b/src/electron/models/prime/regions/tallonOverworld.ts
@@ -104,11 +104,15 @@ export function tallonOverworld(): RegionObject[] {
     {
       name: 'Overgrown Cavern',
       locations: {
-        [PrimeLocation.OVERGROWN_CAVERN]: (items: PrimeItemCollection) => items.has(PrimeItem.MORPH_BALL) && items.has(PrimeItem.SPACE_JUMP_BOOTS) && items.has(PrimeItem.ICE_BEAM)
+        [PrimeLocation.OVERGROWN_CAVERN]: (items: PrimeItemCollection) => items.has(PrimeItem.MORPH_BALL)
       },
       exits: {
-        'Frigate Crash Site': (items: PrimeItemCollection) => items.has(PrimeItem.MORPH_BALL) && items.has(PrimeItem.SPACE_JUMP_BOOTS) && items.has(PrimeItem.ICE_BEAM),
-        [Elevator.TALLON_EAST]: (items: PrimeItemCollection) => items.has(PrimeItem.MORPH_BALL) && items.has(PrimeItem.SPACE_JUMP_BOOTS) && items.has(PrimeItem.ICE_BEAM)
+        'Frigate Crash Site': (items: PrimeItemCollection) => items.has(PrimeItem.MORPH_BALL) && items.has(PrimeItem.ICE_BEAM),
+        [Elevator.TALLON_EAST]: (items: PrimeItemCollection, settings: PrimeRandomizerSettings) => {
+          const baseReqs = items.has(PrimeItem.MORPH_BALL) && items.has(PrimeItem.ICE_BEAM);
+          const sjReqs = (items.has(PrimeItem.SPACE_JUMP_BOOTS) || settings.tricks.tallonTransportTunnelCMinimumReqs);
+          return baseReqs && sjReqs;
+        }
       }
     },
     {
@@ -240,7 +244,11 @@ export function tallonOverworld(): RegionObject[] {
       name: Elevator.TALLON_EAST,
       exits: {
         [Elevator.CHOZO_EAST]: () => true,
-        'Overgrown Cavern': (items: PrimeItemCollection) => items.has(PrimeItem.ICE_BEAM) && items.has(PrimeItem.SPACE_JUMP_BOOTS)
+        'Overgrown Cavern': (items: PrimeItemCollection, settings: PrimeRandomizerSettings) => {
+          const baseReqs = items.has(PrimeItem.MORPH_BALL) && items.has(PrimeItem.ICE_BEAM);
+          const sjReqs = (items.has(PrimeItem.SPACE_JUMP_BOOTS) || settings.tricks.tallonTransportTunnelCMinimumReqs);
+          return baseReqs && sjReqs;
+        }
       }
     },
     {

--- a/src/electron/models/prime/tricks.ts
+++ b/src/electron/models/prime/tricks.ts
@@ -79,6 +79,7 @@ export class Tricks extends SettingsFlags {
   suitlessMagmoorRunMinimal = false;
   sunTowerIbj = false;
   quarantineMonitorDash = false;
+  tallonTransportTunnelCMinimumReqs = false;
   towerChamberNoGravity = false;
   trainingChamberAndAccessOobWallcrawl = false;
   triclopsPitItemWithoutSpaceJump = false;


### PR DESCRIPTION
- Adds a new trick for traversing Transport Tunnel C (Tallon Overworld) with just Morph Ball, and changes the logic to support this trick.
- Removes extraneous requirements for obtaining the Overgrown Cavern B item.
- Reaching Frigate Crash Site from Overgrown Cavern no longer requires Space Jump Boots.

