### PR TITLE
Require missile to break grate in Phendrana Shorelines

### DIFF
--- a/src/electron/models/prime/regions/phendranaDrifts.ts
+++ b/src/electron/models/prime/regions/phendranaDrifts.ts
@@ -29,7 +29,7 @@ export function phendranaDrifts(): RegionObject[] {
           const sjReqs = items.has(PrimeItem.SPACE_JUMP_BOOTS) || (settings.tricks.chozoIceTempleWithoutSpaceJump && items.canLayBombs());
           return sjReqs && canBreakIce(items);
         },
-        'Ice Ruins East': (items: PrimeItemCollection) => (canBreakIce(items) || items.has(PrimeItem.SPACE_JUMP_BOOTS)) && items.has(PrimeItem.SCAN_VISOR),
+        'Ice Ruins East': (items: PrimeItemCollection) => (items.hasMissiles() && items.has(PrimeItem.SCAN_VISOR)) || items.has(PrimeItem.SPACE_JUMP_BOOTS),
         'Ice Ruins West': (items: PrimeItemCollection) => items.has(PrimeItem.SPACE_JUMP_BOOTS),
         [Elevator.PHENDRANA_NORTH]: (items: PrimeItemCollection) => items.hasMissiles() || items.has(PrimeItem.CHARGE_BEAM)
       }


### PR DESCRIPTION
Going from shorelines to ice ruins east requires destroying a grate with missiles. I have replaced the canBreakIce() check as the missiles satisfy that. I have also moved the scan visor requirement to only be included when the player does not have space jump, as you can enter ice ruins east from the upper path.